### PR TITLE
fix argument cpe.getCPEName to sysDescr

### DIFF
--- a/snmp2cpe.py
+++ b/snmp2cpe.py
@@ -26,5 +26,5 @@ logging.debug("[return] getSnmpString")
 logging.debug("  sysName : %s", snmpString[0])
 logging.debug("  sysDescr: %s", snmpString[1])
 
-cpeName = cpe.getCPEName(snmpString[0])
+cpeName = cpe.getCPEName(snmpString[1])
 print(f"sysName  :{snmpString[0]}\ncpeName  :{cpeName}\nsysDescr :{snmpString[1]}")


### PR DESCRIPTION
changed 0 to 1 😀
❌ cpe.getCPEName(snmpString[0])
🟢 cpe.getCPEName(snmpString[1])

```
$ python3 snmp2cpe.py -v 2c -c secret -ip Juniper01
sysName  :Juniper01
cpeName  :cpe:2.3:o:juniper:junos:18.4:r3-s7.2:*:*:*:*:*:*
sysDescr :Juniper Networks, Inc. mx240 internet router, kernel JUNOS 18.4R3-S7.2, Build date: 2021-02-03 13:31:24 UTC Copyright (c) 1996-2021 Juniper Networks, Inc.
$ python3 snmp2cpe.py -v 2c -c secret -ip Juniper02
sysName  :Juniper02
cpeName  :cpe:2.3:o:juniper:junos:20.4:r2-s2.2:*:*:*:*:*:*
sysDescr :Juniper Networks, Inc. ex4300-32f Ethernet Switch, kernel JUNOS 20.4R2-S2.2, Build date: 2021-08-12 00:07:44 UTC Copyright (c) 1996-2021 Juniper Networks, Inc.
```